### PR TITLE
patch update_subscriptions

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -11,6 +11,7 @@ use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc::{Sender, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Instant;
 
 use crate::errors::*;
 use crate::metrics::{Gauge, HistogramOpts, HistogramVec, MetricOpts, Metrics};
@@ -361,12 +362,12 @@ impl Connection {
 
         match self.last_update_status_hashes_time {
             None => {
-                println!("first update");
+                debug!("first update");
                 update_status_hashes = true;
             },
             Some(last_update_status_hashes_time) => {
                 if last_update_status_hashes_time.elapsed().as_secs() >= 60 {
-                    println!(">= 60 seconds passed since last update");
+                    debug!(">= 60 seconds passed since last update");
                     update_status_hashes = true;
                 }
             }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -382,9 +382,9 @@ impl Connection {
                     continue;
                 }
                 result.push(json!({
-                "jsonrpc": "2.0",
-                "method": "blockchain.scripthash.subscribe",
-                "params": [script_hash.to_hex(), new_status_hash]}));
+                    "jsonrpc": "2.0",
+                    "method": "blockchain.scripthash.subscribe",
+                    "params": [script_hash.to_hex(), new_status_hash]}));
                 *status_hash = new_status_hash;
             }
 


### PR DESCRIPTION
Check for a new block will still be every 5 seconds, but actual DB scan and status hashes update will only take place when 60 seconds passed since last update **or** when a new block header is detected.