### PR TITLE
kill periodic update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ name = "backtrace-sys"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "bech32"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -120,30 +120,20 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.18.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitcoin-bech32 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_test 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bitcoin-bech32"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.3.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -166,21 +156,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-helper"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cargo_toml"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
-version = "1.0.26"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -260,16 +252,17 @@ dependencies = [
 
 [[package]]
 name = "configure_me_codegen"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "build-helper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_toml 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fmt2io 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "man 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -341,14 +334,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "electrs"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "configure_me 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "configure_me_codegen 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "configure_me_codegen 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -522,7 +515,7 @@ name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -532,7 +525,7 @@ version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -720,6 +713,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +753,32 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_os"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +789,23 @@ dependencies = [
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -873,19 +936,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "secp256k1"
-version = "0.12.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "semver"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -923,14 +978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_test"
-version = "1.0.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1088,6 +1135,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1196,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "version_check"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1218,17 +1278,16 @@ dependencies = [
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "5b3a000b9c543553af61bc01cbfc403b04b5caa9e421033866f2e98061eb3e61"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
+"checksum bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0089c35ab7c6f2bc55ab23f769913f0ac65b1023e7e74638a1f43128dd5df2"
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
-"checksum bitcoin 0.18.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5e7935f613ba170459072926f01dc5ddb8aa22382dc4badf44bbb55e2d243d"
-"checksum bitcoin-bech32 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e67e8ccfc663811145e6cabdb9a2a6978877f72b048516e83eb95622e9b2554"
-"checksum bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
+"checksum bitcoin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc34f963060a2091b4e285d8082e1946be35caf467e73b3155262c8357fb4595"
+"checksum bitcoin_hashes 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "db6b697833d852acea530c9e815e6adc724267856b6506bc500362a068a39c7b"
 "checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
 "checksum blake2b_simd 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5850aeee1552f495dd0250014cf64b82b7c8879a89d83b33bbdace2cc4f63182"
-"checksum build-helper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdce191bf3fa4995ce948c8c83b4640a1745457a149e73c6db75b4ffe36aad5f"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02"
+"checksum cargo_toml 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7877b00aaf997d7ed66a81281d3a8b9f9da5361df05b72785b985349979a0f3"
+"checksum cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
@@ -1237,7 +1296,7 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum configure_me 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "478e5d56a6bff5d410d9d5871cf6e43546a3b14447ffc64286bc97892d5d3b84"
-"checksum configure_me_codegen 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d7a9e1890b0db5d699b6e68d0ee5b6a620342da484b3a77e6022d23e14c89a9d"
+"checksum configure_me_codegen 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "b5e6b7a013908c8501cfd8aadd56934a28cd9baf66c3a2cb22b368f7e74c8b94"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
@@ -1292,9 +1351,16 @@ dependencies = [
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
@@ -1311,14 +1377,12 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
-"checksum secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfaccd3a23619349e0878d9a241f34b1982343cdf67367058cd7d078d326b63e"
-"checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
+"checksum secp256k1 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4d311229f403d64002e9eed9964dfa5a0a0c1ac443344f7546bf48e916c6053a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
-"checksum serde_test 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4aaf891d32257c9f65259b841af6e0b35d2ee22e41f1becbead01f0217f3e000"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68"
 "checksum signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
@@ -1337,6 +1401,7 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1661fa0a44c95d01604bd05c66732a446c657efb62b5164a7a083a3b552b4951"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+"checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
@@ -1346,6 +1411,7 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrs"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Roman Zeyde <me@romanzey.de>"]
 description = "An efficient re-implementation of Electrum Server in Rust"
 license = "MIT"
@@ -11,6 +11,9 @@ documentation = "https://docs.rs/electrs/"
 readme = "README.md"
 edition = "2018"
 build = "build.rs"
+
+[package.metadata.configure_me]
+spec = "config_spec.toml"
 
 [profile.release]
 lto = true
@@ -47,4 +50,4 @@ time = "0.1"
 tiny_http = "0.6"
 
 [build-dependencies]
-configure_me_codegen = "0.3.8"
+configure_me_codegen = "0.3.12"

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,10 +1,11 @@
-# 0.8.0 (5 Oct 2019)
+# 0.8.0 (28 Oct 2019)
 
 * Use `configure_me` instead of `clap` to support config files, environment variables and man pages (@Kixunil)
 * Don't accept `--cookie` via CLI arguments (@Kixunil)
 * Define cache size in MB instead of number of elements (@dagurval)
 * Support Rust >=1.34 (for Debian)
 * Bump rust-rocksdb to 0.12.3, using RockDB 6.1.2
+* Bump bitcoin crate to 0.21 (@MichelKansou)
 
 # 0.7.1 (27 July 2019)
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate configure_me_codegen;
 
 fn main() -> Result<(), configure_me_codegen::Error> {
-    configure_me_codegen::build_script_with_man("config_spec.toml")
+    configure_me_codegen::build_script_auto()
 }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate configure_me_codegen;
 
 fn main() -> Result<(), configure_me_codegen::Error> {
-    configure_me_codegen::build_script_auto()
+    configure_me_codegen::build_script_with_man("config_spec.toml")
 }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -160,7 +160,7 @@ fn load_headers(daemon: &Daemon) -> Result<HeaderList> {
     let tip = daemon.getbestblockhash()?;
     let mut headers = HeaderList::empty();
     let new_headers = headers.order(daemon.get_new_headers(&headers, &tip)?);
-    headers.apply(new_headers, tip);
+    headers.apply(&new_headers, tip);
     Ok(headers)
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -395,12 +395,14 @@ impl Connection {
     }
 
     fn send_values(&mut self, values: &[Value]) -> Result<()> {
+        debug!("pre send_values");
         for value in values {
             let line = value.to_string() + "\n";
             self.stream
                 .write_all(line.as_bytes())
                 .chain_err(|| format!("failed to send {}", value))?;
         }
+        debug!("post send_values");
         Ok(())
     }
 
@@ -426,7 +428,6 @@ impl Connection {
                     };
                     debug!("before send_values, reply = {}", reply);
                     self.send_values(&[reply])?
-                    debug!("after send_values");
                 }
                 Message::ScriptHashChange(hash) => self.on_scripthash_change(hash)?,
                 Message::ChainTipChange(tip) => self.on_chaintip_change(tip)?,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -203,7 +203,7 @@ impl Connection {
 
     fn blockchain_scripthash_subscribe(&mut self, params: &[Value]) -> Result<Value> {
         let script_hash = hash_from_value(params.get(0)).chain_err(|| "bad script_hash")?;
-        debug!("** blockchain_scripthash_subscribe, script_hash = {}", script_hash);
+        debug!("blockchain_scripthash_subscribe: script_hash = {}", script_hash);
         let status = self.query.status(&script_hash[..])?;
         let result = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
         self.status_hashes.insert(script_hash, result.clone());
@@ -395,14 +395,12 @@ impl Connection {
     }
 
     fn send_values(&mut self, values: &[Value]) -> Result<()> {
-        debug!("pre send_values");
         for value in values {
             let line = value.to_string() + "\n";
             self.stream
                 .write_all(line.as_bytes())
                 .chain_err(|| format!("failed to send {}", value))?;
         }
-        debug!("post send_values");
         Ok(())
     }
 
@@ -426,7 +424,6 @@ impl Connection {
                         ) => self.handle_command(method, params, id)?,
                         _ => bail!("invalid command: {}", cmd),
                     };
-                    debug!("before send_values, reply = {}", reply);
                     self.send_values(&[reply])?
                 }
                 Message::ScriptHashChange(hash) => self.on_scripthash_change(hash)?,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -203,6 +203,7 @@ impl Connection {
 
     fn blockchain_scripthash_subscribe(&mut self, params: &[Value]) -> Result<Value> {
         let script_hash = hash_from_value(params.get(0)).chain_err(|| "bad script_hash")?;
+        debug!("** blockchain_scripthash_subscribe, script_hash = {}", script_hash);
         let status = self.query.status(&script_hash[..])?;
         let result = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
         self.status_hashes.insert(script_hash, result.clone());
@@ -423,7 +424,9 @@ impl Connection {
                         ) => self.handle_command(method, params, id)?,
                         _ => bail!("invalid command: {}", cmd),
                     };
+                    debug!("before send_values, reply = {}", reply);
                     self.send_values(&[reply])?
+                    debug!("after send_values");
                 }
                 Message::ScriptHashChange(hash) => self.on_scripthash_change(hash)?,
                 Message::ChainTipChange(tip) => self.on_chaintip_change(tip)?,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -2,20 +2,22 @@ use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin_hashes::hex::{FromHex, ToHex};
 use bitcoin_hashes::sha256d::Hash as Sha256dHash;
+use bitcoin_hashes::Hash;
 use error_chain::ChainedError;
 use hex;
 use serde_json::{from_str, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc::{Sender, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Instant;
 
 use crate::errors::*;
+use crate::index::compute_script_hash;
 use crate::metrics::{Gauge, HistogramOpts, HistogramVec, MetricOpts, Metrics};
 use crate::query::{Query, Status};
+use crate::util::FullHash;
 use crate::util::{spawn_thread, Channel, HeaderEntry, SyncChannel};
 
 const ELECTRS_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -73,7 +75,6 @@ fn unspent_from_status(status: &Status) -> Value {
 struct Connection {
     query: Arc<Query>,
     last_header_entry: Option<HeaderEntry>,
-    last_update_status_hashes_time: Option<Instant>,
     status_hashes: HashMap<Sha256dHash, Value>, // ScriptHash -> StatusHash
     stream: TcpStream,
     addr: SocketAddr,
@@ -91,7 +92,6 @@ impl Connection {
         Connection {
             query,
             last_header_entry: None, // disable header subscription for now
-            last_update_status_hashes_time: None,
             status_hashes: HashMap::new(),
             stream,
             addr,
@@ -206,6 +206,9 @@ impl Connection {
         let status = self.query.status(&script_hash[..])?;
         let result = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
         self.status_hashes.insert(script_hash, result.clone());
+        self.stats
+            .subscriptions
+            .set(self.status_hashes.len() as i64);
         Ok(result)
     }
 
@@ -240,10 +243,6 @@ impl Connection {
         let tx = hex::decode(&tx).chain_err(|| "non-hex tx")?;
         let tx: Transaction = deserialize(&tx).chain_err(|| "failed to parse tx")?;
         let txid = self.query.broadcast(&tx)?;
-        self.query.update_mempool()?;
-        if let Err(e) = self.chan.sender().try_send(Message::PeriodicUpdate) {
-            warn!("failed to issue PeriodicUpdate after broadcast: {}", e);
-        }
         Ok(json!(txid.to_hex()))
     }
 
@@ -335,67 +334,63 @@ impl Connection {
         })
     }
 
-    fn update_subscriptions(&mut self) -> Result<Vec<Value>> {
-        debug!("----------------- update_subscriptions -----------------");
+    fn on_scripthash_change(&mut self, scripthash: FullHash) -> Result<()> {
+        let scripthash = Sha256dHash::from_slice(&scripthash[..]).expect("invalid scripthash");
+
+        let old_statushash;
+        match self.status_hashes.get(&scripthash) {
+            Some(statushash) => {
+                old_statushash = statushash;
+            }
+            None => {
+                return Ok(());
+            }
+        };
+
         let timer = self
             .stats
             .latency
-            .with_label_values(&["periodic_update"])
+            .with_label_values(&["statushash_update"])
             .start_timer();
-        let mut result = vec![];
-        let mut update_status_hashes = false;
+
+        let status = self.query.status(&scripthash[..])?;
+        let new_statushash = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
+        if new_statushash == *old_statushash {
+            return Ok(());
+        }
+        timer.observe_duration();
+        self.send_values(&vec![json!({
+            "jsonrpc": "2.0",
+            "method": "blockchain.scripthash.subscribe",
+            "params": [scripthash.to_hex(), new_statushash]})])?;
+        self.status_hashes.insert(scripthash, new_statushash);
+        Ok(())
+    }
+
+    fn on_chaintip_change(&mut self, chaintip: HeaderEntry) -> Result<()> {
+        let timer = self
+            .stats
+            .latency
+            .with_label_values(&["chaintip_update"])
+            .start_timer();
+
         if let Some(ref mut last_entry) = self.last_header_entry {
-            let entry = self.query.get_best_header()?;
-            if *last_entry != entry {
-                *last_entry = entry;
-                let hex_header = hex::encode(serialize(last_entry.header()));
-                let header = json!({"hex": hex_header, "height": last_entry.height()});
-                result.push(json!({
+            if *last_entry == chaintip {
+                return Ok(());
+            }
+
+            *last_entry = chaintip;
+            let hex_header = hex::encode(serialize(last_entry.header()));
+            let header = json!({"hex": hex_header, "height": last_entry.height()});
+            self.send_values(&vec![
+                (json!({
                     "jsonrpc": "2.0",
                     "method": "blockchain.headers.subscribe",
-                    "params": [header]}));
-
-                debug!("discovered new block hash = {}", hex_header);
-                update_status_hashes = true;
-            }
+                    "params": [header]})),
+            ])?;
         }
-
-        match self.last_update_status_hashes_time {
-            None => {
-                debug!("first update");
-                update_status_hashes = true;
-            },
-            Some(last_update_status_hashes_time) => {
-                if last_update_status_hashes_time.elapsed().as_secs() >= 60 {
-                    debug!(">= 60 seconds passed since last update");
-                    update_status_hashes = true;
-                }
-            }
-        }
-
-        if update_status_hashes {
-            debug!("updating...");
-            for (script_hash, status_hash) in self.status_hashes.iter_mut() {
-                let status = self.query.status(&script_hash[..])?;
-                let new_status_hash = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
-                if new_status_hash == *status_hash {
-                    continue;
-                }
-                result.push(json!({
-                    "jsonrpc": "2.0",
-                    "method": "blockchain.scripthash.subscribe",
-                    "params": [script_hash.to_hex(), new_status_hash]}));
-                *status_hash = new_status_hash;
-            }
-
-            self.last_update_status_hashes_time = Some(Instant::now());
-        }
-
         timer.observe_duration();
-        self.stats
-            .subscriptions
-            .set(self.status_hashes.len() as i64);
-        Ok(result)
+        Ok(())
     }
 
     fn send_values(&mut self, values: &[Value]) -> Result<()> {
@@ -412,9 +407,9 @@ impl Connection {
         let empty_params = json!([]);
         loop {
             let msg = self.chan.receiver().recv().chain_err(|| "channel closed")?;
-            trace!("RPC {:?}", msg);
             match msg {
                 Message::Request(line) => {
+                    trace!("RPC {:?}", line);
                     let cmd: Value = from_str(&line).chain_err(|| "invalid JSON format")?;
                     let reply = match (
                         cmd.get("method"),
@@ -430,12 +425,8 @@ impl Connection {
                     };
                     self.send_values(&[reply])?
                 }
-                Message::PeriodicUpdate => {
-                    let values = self
-                        .update_subscriptions()
-                        .chain_err(|| "failed to update subscriptions")?;
-                    self.send_values(&values)?
-                }
+                Message::ScriptHashChange(hash) => self.on_scripthash_change(hash)?,
+                Message::ChainTipChange(tip) => self.on_chaintip_change(tip)?,
                 Message::Done => return Ok(()),
             }
         }
@@ -491,18 +482,21 @@ impl Connection {
 #[derive(Debug)]
 pub enum Message {
     Request(String),
-    PeriodicUpdate,
+    ScriptHashChange(FullHash),
+    ChainTipChange(HeaderEntry),
     Done,
 }
 
 pub enum Notification {
-    Periodic,
+    ScriptHashChange(FullHash),
+    ChainTipChange(HeaderEntry),
     Exit,
 }
 
 pub struct RPC {
     notification: Sender<Notification>,
     server: Option<thread::JoinHandle<()>>, // so we can join the server while dropping this ojbect
+    query: Arc<Query>,
 }
 
 struct Stats {
@@ -520,10 +514,20 @@ impl RPC {
             for msg in notification.receiver().iter() {
                 let mut senders = senders.lock().unwrap();
                 match msg {
-                    Notification::Periodic => {
+                    Notification::ScriptHashChange(hash) => {
                         for sender in senders.split_off(0) {
                             if let Err(TrySendError::Disconnected(_)) =
-                                sender.try_send(Message::PeriodicUpdate)
+                                sender.try_send(Message::ScriptHashChange(hash))
+                            {
+                                continue;
+                            }
+                            senders.push(sender);
+                        }
+                    }
+                    Notification::ChainTipChange(hash) => {
+                        for sender in senders.split_off(0) {
+                            if let Err(TrySendError::Disconnected(_)) =
+                                sender.try_send(Message::ChainTipChange(hash.clone()))
                             {
                                 continue;
                             }
@@ -571,6 +575,7 @@ impl RPC {
         let notification = Channel::unbounded();
         RPC {
             notification: notification.sender(),
+            query: query.clone(),
             server: Some(spawn_thread("rpc", move || {
                 let senders = Arc::new(Mutex::new(Vec::<SyncSender<Message>>::new()));
                 let acceptor = RPC::start_acceptor(addr);
@@ -601,8 +606,105 @@ impl RPC {
         }
     }
 
-    pub fn notify(&self) {
-        self.notification.send(Notification::Periodic).unwrap();
+    /// Attempt to notify scripthash subscriptions affected by transaction.
+    /// The `notified` hashset is an optimization to avoid double notifications.
+    /// When `notify_inputs` is set, we also notify scripthashes that are spent from.
+    fn try_notify_subscriptions_for_tx(
+        &self,
+        txid: &Sha256dHash,
+        mut blockhash: Option<Sha256dHash>,
+        notified: &mut HashSet<Sha256dHash>,
+        notify_inputs: bool,
+    ) -> Result<()> {
+        if notified.contains(txid) {
+            return Ok(());
+        }
+        notified.insert(txid.clone());
+
+        if blockhash.is_none() {
+            match self.query.lookup_confirmed_blockhash(txid, None) {
+                Ok(hash) => blockhash = hash,
+                Err(err) => trace!("Failed to lookup blockhash for {}: {}", txid, err),
+            };
+        }
+
+        let txn = self.query.load_txn(txid, blockhash)?;
+
+        let scripthashes: Vec<FullHash> = txn
+            .output
+            .iter()
+            .map(|o| compute_script_hash(&o.script_pubkey[..]))
+            .collect();
+
+        for s in scripthashes {
+            if let Err(e) = self.notification.send(Notification::ScriptHashChange(s)) {
+                trace!("ScriptHash change notification failed {}", e);
+            }
+        }
+
+        if notify_inputs {
+            for txin in txn.input {
+                if txin.previous_output.is_null() {
+                    continue;
+                }
+                let id: &Sha256dHash = &txin.previous_output.txid;
+
+                if let Err(e) = self.try_notify_subscriptions_for_tx(id, None, notified, false) {
+                    trace!("failed to load input transaction {}: {}", id, e);
+                    continue;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn notify_scripthash_subscriptions(
+        &self,
+        changed_headers: &Vec<HeaderEntry>,
+        changed_mempool_txs: HashSet<Sha256dHash>,
+    ) {
+        // Keep track of which txs have been notified, so we don't spend time
+        // notifying them twice.
+        let mut notified: HashSet<Sha256dHash> = HashSet::new();
+
+        for txid in changed_mempool_txs {
+            if let Err(e) = self.try_notify_subscriptions_for_tx(&txid, None, &mut notified, true) {
+                trace!("Failed notifying subscriptions {}", e);
+            }
+        }
+
+        for header in changed_headers {
+            let blockhash = header.hash();
+            let res = self.query.with_blocktxids(&blockhash, |txid| {
+                if let Err(e) = self.try_notify_subscriptions_for_tx(
+                    &txid,
+                    Some(*blockhash),
+                    &mut notified,
+                    true,
+                ) {
+                    trace!("Failed notifying subscriptions {}", e);
+                    return;
+                }
+            });
+            if let Err(e) = res {
+                trace!(
+                    "Failed to fetch transactions for block {}: {}",
+                    blockhash,
+                    e
+                );
+            }
+        }
+    }
+
+    pub fn notify_subscriptions_chaintip(&self, header: HeaderEntry) {
+        if let Err(e) = self.notification.send(Notification::ChainTipChange(header)) {
+            trace!("Failed to notify about chaintip change {}", e);
+        }
+    }
+
+    pub fn disconnect_clients(&self) {
+        trace!("disconncting clients");
+        self.notification.send(Notification::Exit).unwrap();
     }
 }
 


### PR DESCRIPTION
This removes the expensive `PeriodicUpdate` call from the application loop.

`PeriodicUpdate` would iterate through every subscription of every connected client and re-calculate its status to look for differences.

The new code calculates which subscription need update and notifies each RPC connection. If, and only if, a client is subscribed will it re-calculate its status.