### PR TITLE
Make DynamoDB status hashes comparison non-blocking

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -508,8 +508,9 @@ impl Connection {
             }
 
             debug!("compare_status_hashes: found diff. scripthash = {}, old_statushash = {}, new_statushash = {}", scripthash, old_statushash, new_statushash);
-            tx.send(Message::ScriptHashChange(scripthash_buffer, None))
-                .expect("send error");
+            if let Err(_) = tx.send(Message::ScriptHashChange(scripthash_buffer, None)) {
+                debug!("compare_status_hashes: send failed because the channel is closed, shutting down")
+            }
         }
 
         debug!("compare_status_hashes: script_hashes.len() = {}, took {} seconds", script_hashes.len(), now.elapsed().as_secs());

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -97,7 +97,7 @@ impl Connection {
         let now = Instant::now();
         let script_hashes = SubscriptionsManager::get_script_hashes()
             .unwrap_or(HashMap::new());
-        debug!("subscribed_script_hashes.len() = {}, took {} milliseconds", script_hashes.len(), now.elapsed().as_millis());
+        debug!("script_hashes.len() = {}, took {} milliseconds", script_hashes.len(), now.elapsed().as_millis());
         Connection {
             query,
             last_header_entry: None, // disable header subscription for now
@@ -485,6 +485,7 @@ impl Connection {
     }
 
     fn compare_status_hashes(script_hashes: HashMap<Sha256dHash, Value>, query: Arc<Query>, tx: SyncSender<Message>) -> Result<()> {
+        debug!("compare_status_hashes: script_hashes.len() = {}, starting");
         let now = Instant::now();
         for scripthash in script_hashes.keys() {
             let old_statushash;
@@ -509,7 +510,7 @@ impl Connection {
                 .expect("send error");
         }
 
-        debug!("compare_status_hashes: {} script_hashes, took {} seconds.", script_hashes.len(), now.elapsed().as_secs());
+        debug!("compare_status_hashes: script_hashes.len() = {}, took {} seconds", script_hashes.len(), now.elapsed().as_secs());
         Ok(())
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -488,13 +488,16 @@ impl Connection {
         debug!("compare_status_hashes: script_hashes.len() = {}, starting", script_hashes.len());
         let now = Instant::now();
         let rx = connection.receiver();
-        for scripthash in script_hashes.keys() {
-            match rx.try_recv() {
-                Ok(_) | Err(TryRecvError::Disconnected) => {
-                    debug!("compare_status_hashes: channel is closed, shutting down");
-                    break;
+        for (i, scripthash) in script_hashes.keys().enumerate() {
+            if i % 1000 == 0 {
+                debug!("compare_status_hashes: comparing {} out of {}", i, script_hashes.len());
+                match rx.try_recv() {
+                    Ok(_) | Err(TryRecvError::Disconnected) => {
+                        debug!("compare_status_hashes: channel is closed, shutting down");
+                        break;
+                    }
+                    Err(TryRecvError::Empty) => {}
                 }
-                Err(TryRecvError::Empty) => {}
             }
 
             let old_statushash;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -98,25 +98,16 @@ impl Connection {
         let script_hashes = SubscriptionsManager::get_script_hashes()
             .unwrap_or(HashMap::new());
         debug!("subscribed_script_hashes.len() = {}, took {} milliseconds", script_hashes.len(), now.elapsed().as_millis());
-        let mut conn = Connection {
+        Connection {
             query,
             last_header_entry: None, // disable header subscription for now
-            script_hashes: script_hashes.clone(),
+            script_hashes,
             stream,
             addr,
             chan: SyncChannel::new(10),
             stats,
             relayfee,
-        };
-
-        let now = Instant::now();
-        for script_hash in script_hashes.keys() {
-            conn.on_scripthash_change(script_hash.into_inner(), None)
-                .expect("Failed while comparing status hashes");
         }
-        debug!("Connection::run, comparing status hashes took {} seconds", now.elapsed().as_secs());
-
-        conn
     }
 
     fn blockchain_headers_subscribe(&mut self) -> Result<Value> {
@@ -458,7 +449,7 @@ impl Connection {
                     };
                     self.send_values(&[reply])?
                 }
-                Message::ScriptHashChange(hash, txid) => self.on_scripthash_change(hash, Some(txid))?,
+                Message::ScriptHashChange(hash, txid) => self.on_scripthash_change(hash, txid)?,
                 Message::ChainTipChange(tip) => self.on_chaintip_change(tip)?,
                 Message::Done => return Ok(()),
             }
@@ -493,10 +484,45 @@ impl Connection {
         }
     }
 
+    fn compare_status_hashes(script_hashes: HashMap<Sha256dHash, Value>, query: Arc<Query>, tx: SyncSender<Message>) -> Result<()> {
+        let now = Instant::now();
+        for scripthash in script_hashes.keys() {
+            let old_statushash;
+            match script_hashes.get(scripthash) {
+                Some(statushash) => {
+                    old_statushash = statushash;
+                }
+                None => {
+                    return Ok(());
+                }
+            };
+
+            let scripthash_buffer = scripthash.into_inner();
+            let status = query.status(&scripthash_buffer)?;
+            let new_statushash = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
+            if new_statushash == *old_statushash {
+                continue;
+            }
+
+            debug!("compare_status_hashes: found diff. scripthash = {}, old_statushash = {}, new_statushash = {}", scripthash, old_statushash, new_statushash);
+            tx.send(Message::ScriptHashChange(scripthash_buffer, None))
+                .expect("send error");
+        }
+
+        debug!("compare_status_hashes: {} script_hashes, took {} seconds.", script_hashes.len(), now.elapsed().as_secs());
+        Ok(())
+    }
+
     pub fn run(mut self) {
         let reader = BufReader::new(self.stream.try_clone().expect("failed to clone TcpStream"));
         let tx = self.chan.sender();
-        let child = spawn_thread("reader", || Connection::handle_requests(reader, tx));
+        let reader_child = spawn_thread("reader", || Connection::handle_requests(reader, tx));
+
+        let script_hashes = self.script_hashes.clone();
+        let query = Arc::clone(&self.query);
+        let tx2 = self.chan.sender();
+        let status_hashes_child = spawn_thread("status_hashes_comparer", || Connection::compare_status_hashes(script_hashes, query, tx2));
+
         if let Err(e) = self.handle_replies() {
             error!(
                 "[{}] connection handling failed: {}",
@@ -506,7 +532,10 @@ impl Connection {
         }
         debug!("[{}] shutting down connection", self.addr);
         let _ = self.stream.shutdown(Shutdown::Both);
-        if let Err(err) = child.join().expect("receiver panicked") {
+        if let Err(err) = reader_child.join().expect("receiver panicked") {
+            error!("[{}] receiver failed: {}", self.addr, err);
+        }
+        if let Err(err) = status_hashes_child.join().expect("status hashes comparer panicked") {
             error!("[{}] receiver failed: {}", self.addr, err);
         }
     }
@@ -515,7 +544,7 @@ impl Connection {
 #[derive(Debug)]
 pub enum Message {
     Request(String),
-    ScriptHashChange(FullHash, FullHash),
+    ScriptHashChange(FullHash, Option<FullHash>),
     ChainTipChange(HeaderEntry),
     Done,
 }
@@ -550,7 +579,7 @@ impl RPC {
                     Notification::ScriptHashChange(hash, txid) => {
                         for sender in senders.split_off(0) {
                             if let Err(TrySendError::Disconnected(_)) =
-                                sender.try_send(Message::ScriptHashChange(hash, txid))
+                                sender.try_send(Message::ScriptHashChange(hash, Some(txid)))
                             {
                                 continue;
                             }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -485,7 +485,7 @@ impl Connection {
     }
 
     fn compare_status_hashes(script_hashes: HashMap<Sha256dHash, Value>, query: Arc<Query>, tx: SyncSender<Message>) -> Result<()> {
-        debug!("compare_status_hashes: script_hashes.len() = {}, starting");
+        debug!("compare_status_hashes: script_hashes.len() = {}, starting", script_hashes.len());
         let now = Instant::now();
         for scripthash in script_hashes.keys() {
             let old_statushash;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -484,7 +484,7 @@ impl Connection {
         }
     }
 
-    fn compare_status_hashes(script_hashes: HashMap<Sha256dHash, Value>, query: Arc<Query>, tx: SyncSender<Message>, connection: SyncChannel<_>) -> Result<()> {
+    fn compare_status_hashes(script_hashes: HashMap<Sha256dHash, Value>, query: Arc<Query>, tx: SyncSender<Message>, connection: SyncChannel<Message>) -> Result<()> {
         debug!("compare_status_hashes: script_hashes.len() = {}, starting", script_hashes.len());
         let now = Instant::now();
         let rx = connection.receiver();
@@ -544,7 +544,7 @@ impl Connection {
         }
         debug!("[{}] shutting down connection", self.addr);
         let _ = self.stream.shutdown(Shutdown::Both);
-        let _ = shutdown_sender.send(true);
+        let _ = shutdown_sender.send(Message::Done);
         if let Err(err) = reader_child.join().expect("receiver panicked") {
             error!("[{}] receiver failed: {}", self.addr, err);
         }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -491,7 +491,7 @@ impl Connection {
         for scripthash in script_hashes.keys() {
             match rx.try_recv() {
                 Ok(_) | Err(TryRecvError::Disconnected) => {
-                    println!("compare_status_hashes: channel is closed, shutting down");
+                    debug!("compare_status_hashes: channel is closed, shutting down");
                     break;
                 }
                 Err(TryRecvError::Empty) => {}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -488,7 +488,7 @@ impl Connection {
         debug!("compare_status_hashes: script_hashes.len() = {}, starting", script_hashes.len());
         let now = Instant::now();
         let rx = connection.receiver();
-        for (i, scripthash) in script_hashes.keys().enumerate() {
+        for (i, (scripthash, old_statushash)) in script_hashes.iter().enumerate() {
             if i % 1000 == 0 {
                 debug!("compare_status_hashes: comparing {} out of {}", i, script_hashes.len());
                 match rx.try_recv() {
@@ -499,16 +499,6 @@ impl Connection {
                     Err(TryRecvError::Empty) => {}
                 }
             }
-
-            let old_statushash;
-            match script_hashes.get(scripthash) {
-                Some(statushash) => {
-                    old_statushash = statushash;
-                }
-                None => {
-                    return Ok(());
-                }
-            };
 
             let scripthash_buffer = scripthash.into_inner();
             let status = query.status(&scripthash_buffer)?;


### PR DESCRIPTION
Previously, the comparison between the DynamoDB status hashes and the updated status hashes from the indexed blockchain took place in each new Connection creation, which was blocking the "peer" thread. This caused the first JSON-RPC response to halt until the comparison is over. 

This PR: first subscribes the DB addresses (as before), then spawns the comparison on a separate thread, allowing requests to get fast responses and notify status hash changes in the background.