### PR TITLE
fix missed notifications

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -214,7 +214,8 @@ impl Query {
         for txid_prefix in prefixes {
             for tx_row in txrows_by_prefix(store, txid_prefix) {
                 let txid: Txid = deserialize(&tx_row.key.txid).unwrap();
-                let txn = self.load_txn(&txid, Some(tx_row.height))?;
+                let blockhash = self.lookup_confirmed_blockhash(&txid, Some(tx_row.height))?;
+                let txn = self.load_txn(&txid, blockhash)?;
                 txns.push(TxnHeight {
                     txn,
                     height: tx_row.height,
@@ -368,11 +369,32 @@ impl Query {
         Ok(blockhash)
     }
 
-    // Internal API for transaction retrieval
-    pub fn load_txn(&self, txid: &Txid, block_height: Option<u32>) -> Result<Transaction> {
+    /// Load transaction by ID, attempt to lookup blockhash locally.
+    pub fn load_txn_with_blockhashlookup(
+        &self,
+        txid: &Txid,
+        blockhash: Option<BlockHash>,
+    ) -> Result<Transaction> {
+        if let Some(tx) = self.tracker.read().unwrap().get_txn(&txid) {
+            return Ok(tx);
+        }
+        let hash: Option<BlockHash> = match blockhash {
+            Some(hash) => Some(hash),
+            None => match self.lookup_confirmed_blockhash(txid, None) {
+                Ok(hash) => hash,
+                Err(_) => None,
+            },
+        };
+        self.load_txn(txid, hash)
+    }
+
+    pub fn load_txn(
+        &self,
+        txid: &Txid,
+        blockhash: Option<BlockHash>,
+    ) -> Result<Transaction> {
         let _timer = self.duration.with_label_values(&["load_txn"]).start_timer();
         self.tx_cache.get_or_else(&txid, || {
-            let blockhash = self.lookup_confirmed_blockhash(txid, block_height)?;
             let value: Value = self
                 .app
                 .daemon()
@@ -381,6 +403,7 @@ impl Query {
             hex::decode(&value_hex).chain_err(|| "non-hex tx")
         })
     }
+
     // Public API for transaction retrieval (for Electrum RPC)
     pub fn get_transaction(&self, tx_hash: &Txid, verbose: bool) -> Result<Value> {
         let _timer = self
@@ -410,15 +433,8 @@ impl Query {
         Ok(last_header.chain_err(|| "no headers indexed")?.clone())
     }
 
-    pub fn with_blocktxids<F>(&self, blockhash: &BlockHash, mut callb: F) -> Result<()>
-    where
-        F: FnMut(&Txid),
-    {
-        let txid = self.app.daemon().getblocktxids(blockhash)?;
-        for t in txid {
-            callb(&t)
-        }
-        Ok(())
+    pub fn get_block_txids(&self, blockhash: &BlockHash) -> Result<Vec<Txid>> {
+        self.app.daemon().getblocktxids(blockhash)
     }
 
     pub fn get_merkle_proof(

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -366,7 +366,11 @@ impl Connection {
         let old_statushash;
         match self.script_hashes.get(&scripthash) {
             Some(statushash) => {
-                debug!("on_scripthash_change: scripthash = {}, statushash = {}, txid_opt = {:?}", scripthash, statushash, txid_opt);
+                debug!("on_scripthash_change: scripthash = {}, statushash = {}{}",
+                    scripthash,
+                    statushash,
+                    txid_opt.map_or("".to_string(), |txid| format!(", txid = {}", txid))
+                );
                 old_statushash = statushash;
             }
             None => {
@@ -387,11 +391,12 @@ impl Connection {
         }
         timer.observe_duration();
 
-        if txid_opt.is_some() {
-            debug!("ScriptHash change: scripthash = {}, tx_hash = {}, statushash = {}", scripthash, txid_opt.unwrap(), new_statushash);
-        } else {
-            debug!("ScriptHash change: scripthash = {}, old_statushash = {}, new_statushash = {}", scripthash, old_statushash, new_statushash);
-        }
+        debug!("ScriptHash change: scripthash = {}, old_statushash = {}, new_statushash = {}{}",
+            scripthash,
+            old_statushash,
+            new_statushash,
+            txid_opt.map_or("".to_string(), |txid| format!(", txid = {}", txid))
+        );
 
         self.send_values(&vec![json!({
             "jsonrpc": "2.0",

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -727,7 +727,7 @@ impl RPC {
                     scripthashes.insert(h, txid);
                 }
             } else {
-                trace!("failed to get effected scripthashes for tx {}", txid);
+                warn!("failed to get effected scripthashes for tx {}", txid);
             }
         };
 
@@ -750,14 +750,14 @@ impl RPC {
 
         for (scripthash, txid) in scripthashes.drain() {
             if let Err(e) = self.notification.send(Notification::ScriptHashChange(scripthash, txid.into_inner())) {
-                trace!("Scripthash change notification failed: {}", e);
+                warn!("Scripthash change notification failed: {}", e);
             }
         }
     }
 
     pub fn notify_subscriptions_chaintip(&self, header: HeaderEntry) {
         if let Err(e) = self.notification.send(Notification::ChainTipChange(header)) {
-            trace!("Failed to notify about chaintip change {}", e);
+            warn!("Failed to notify about chaintip change {}", e);
         }
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -114,7 +114,7 @@ impl Connection {
             script_hashes,
             stream,
             addr,
-            chan: SyncChannel::new(100),
+            chan: SyncChannel::new(10),
             stats,
             relayfee,
         }


### PR DESCRIPTION
The key issue with missing notifications is the inter-process communication between the notification and the connection threads. 
The notification thread used `try_send` which was silently failing when the buffer of the connection thread's receiver was full.
Switching into `send` makes sure that the transactions would go through, as it _blocks_ the thread until the buffer makes room for more requests.

This PR also holds a fix for notifying previous transactions - previously _all_ addresses (Script hashes) in a previous transaction were notified for. 
Now it strictly checks for the exact spent output index in the previous transaction, which saves some amount of messages between threads, as well as checks on the receiving process side.