### PR TITLE
Increase transaction limit

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -103,7 +103,7 @@ default = "250"
 name = "txid_limit"
 type = "usize"
 doc = "Number of transactions to lookup before returning an error, to prevent 'too popular' addresses from causing the RPC server to get stuck (0 - disable the limit)"
-default = "300"
+default = "400"
 
 [[param]]
 name = "server_banner"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -103,7 +103,7 @@ default = "250"
 name = "txid_limit"
 type = "usize"
 doc = "Number of transactions to lookup before returning an error, to prevent 'too popular' addresses from causing the RPC server to get stuck (0 - disable the limit)"
-default = "400"
+default = "0"
 
 [[param]]
 name = "server_banner"


### PR DESCRIPTION
In order to allow wallets with more than 300 outputs on a single address to spend their funds from that address, we have changed the limit to 0 effectively removing it the transaction limit in order to list the unspent outputs of this address